### PR TITLE
Changing the calculation of the BX (for the trigger primitives) to us…

### DIFF
--- a/EventFilter/DTRawToDigi/plugins/OglezDTAB7RawToDigi.cc
+++ b/EventFilter/DTRawToDigi/plugins/OglezDTAB7RawToDigi.cc
@@ -512,7 +512,7 @@ void OglezDTAB7RawToDigi::readAB7PayLoad_triggerPrimitive (long firstWord,long s
   // The time may need to be corrected to use the "L1A time" as the reference:
   if (correctTPTimeToL1A_) time -= 25*bxCounter_;
 
-  int bx = time/25;  // Bunch crossing in LHC notation (as I understand the "0")
+  int bx = (int) round(time/25.);   // Getting the associated bunch-crossing (as indicated by Jaime how they computed in the emulator).
   if (bx<0) bx += 3564;  // BX in previous orbit!
 
 //v4  int position = ((firstWord)&0xFFFF);   // Bits 0-15 (first word) is the position (phi or theta depending on SL)


### PR DESCRIPTION
…e the convention used in the Emulator, where the first BX is centered at 0 ns instead of at 12.5 ns

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, what changes are expected in the output if any, what other PRs or externals it depends upon if any -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
